### PR TITLE
Optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ authors = ["Tony Solomonik"]
 strip = true
 lto = true
 
+[profile.release-thin-lto]
+inherits = "release"
+lto = "thin"
+
 [features]
 flow-events = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ async-channel = "1.8.0"
 bincode = "1.3.3"
 bloomfilter = { version = "1.0.12", features = ["serde"] }
 clap = { version = "4.2.7", features = ["derive"] }
-event-listener = "3.0.0"
 from-num = { path = "from_num" }
 futures = "0.3.28"
 futures-lite = "1.12.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,8 @@ pub enum Error {
     CollectionNotFound(String),
     #[error("collection '{0}' already exists")]
     CollectionAlreadyExists(String),
+    #[error("item too large")]
+    ItemTooLarge,
     #[error("key not found")]
     KeyNotFound,
     #[error("msgpack decode failed")]

--- a/src/shards.rs
+++ b/src/shards.rs
@@ -308,7 +308,7 @@ impl MyShard {
         dir
     }
 
-    async fn create_lsm_tree(&self, name: String) -> Result<LSMTree> {
+    async fn create_lsm_tree(&self, name: &str) -> Result<LSMTree> {
         let cache = self.cache.clone();
 
         let wal_sync_delay = if self.args.wal_sync {
@@ -318,8 +318,8 @@ impl MyShard {
         };
 
         LSMTree::open_or_create_ex(
-            self.get_collection_dir(&name),
-            PartitionPageCache::new(name, cache),
+            self.get_collection_dir(name),
+            PartitionPageCache::new_named(name, cache)?,
             DEFAULT_TREE_CAPACITY,
             wal_sync_delay,
             self.args.sstable_bloom_min_size,
@@ -335,7 +335,7 @@ impl MyShard {
         if self.collections.borrow().contains_key(&name) {
             return Err(Error::CollectionAlreadyExists(name));
         }
-        let tree = self.create_lsm_tree(name.clone()).await?;
+        let tree = self.create_lsm_tree(&name).await?;
         let metadata = CollectionMetadata { replication_factor };
 
         let path = self.get_collection_metadata_path(&name);

--- a/src/shards.rs
+++ b/src/shards.rs
@@ -22,7 +22,6 @@ use murmur3::murmur3_32;
 use rand::seq::IteratorRandom;
 use rand::thread_rng;
 use regex::Regex;
-use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -47,6 +46,9 @@ use crate::{
         page_cache::{PageCache, PartitionPageCache},
     },
 };
+
+#[cfg(feature = "flow-events")]
+use rustc_hash::FxHashMap;
 
 #[cfg(feature = "flow-events")]
 use crate::flow_events::{FlowEvent, FlowEventKind};

--- a/src/storage_engine/cached_file_reader.rs
+++ b/src/storage_engine/cached_file_reader.rs
@@ -4,14 +4,17 @@ use event_listener::Event;
 use glommio::io::DmaFile;
 use rustc_hash::FxHashMap;
 
-use super::page_cache::{align_down, align_up, PartitionPageCache, PAGE_SIZE};
+use super::{
+    page_cache::{align_down, align_up, PartitionPageCache, PAGE_SIZE},
+    FileTypeKind,
+};
 use crate::error::Result;
 
 /// Number of times to try to get from the cache right after waiting for the
 /// page to be read.
 const RETRIES: usize = 2;
 
-pub type FileId = (&'static str, usize);
+pub type FileId = (FileTypeKind, usize);
 
 pub struct CachedFileReader {
     id: FileId,

--- a/src/storage_engine/entry_writer.rs
+++ b/src/storage_engine/entry_writer.rs
@@ -75,9 +75,12 @@ impl EntryWriter {
         let data_encoded = bincode_options().serialize(entry)?;
         let data_size = data_encoded.len();
 
+        let key_size = bincode_options().serialized_size(&entry.key)? as u32;
+
         let entry_index = EntryOffset {
             offset: self.data_written as u64,
-            size: data_size as u32,
+            key_size,
+            full_size: data_size as u32,
         };
         let index_encoded = bincode_options().serialize(&entry_index)?;
         let index_size = index_encoded.len();

--- a/src/storage_engine/lsm_tree.rs
+++ b/src/storage_engine/lsm_tree.rs
@@ -244,7 +244,10 @@ impl<'a> AsyncIter<'a> {
                     bincode_options().deserialize(&self.index_buffer)?;
                 let entry: Entry = bincode_options().deserialize(
                     &data_file
-                        .read_at(entry_offset.offset, entry_offset.size)
+                        .read_at(
+                            entry_offset.offset,
+                            entry_offset.size as usize,
+                        )
                         .await?,
                 )?;
 
@@ -610,7 +613,9 @@ impl LSMTree {
                 bincode_options().deserialize(&index_buf)?;
 
             let entry: Entry = bincode_options().deserialize(
-                &data_file.read_at(current.offset, current.size).await?,
+                &data_file
+                    .read_at(current.offset, current.size as usize)
+                    .await?,
             )?;
 
             match entry.key.cmp(key) {
@@ -1122,7 +1127,7 @@ impl LSMTree {
         index_reader.read_exact(offset_bytes).await?;
         let entry_offset: EntryOffset =
             bincode_options().deserialize(offset_bytes)?;
-        let mut data_bytes = vec![0; entry_offset.size];
+        let mut data_bytes = vec![0; entry_offset.size as usize];
         data_reader.read_exact(&mut data_bytes).await?;
         let entry: Entry = bincode_options().deserialize(&data_bytes)?;
         Ok(entry)

--- a/src/storage_engine/mod.rs
+++ b/src/storage_engine/mod.rs
@@ -41,6 +41,7 @@ pub enum FileType {
     Bloom,
 }
 
+// Remember to change the INDEX_ENTRY_SIZE const when you change this struct.
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct EntryOffset {
     offset: u64,

--- a/src/storage_engine/mod.rs
+++ b/src/storage_engine/mod.rs
@@ -30,7 +30,7 @@ const COMPACT_BLOOM_FILE_EXT: &str = "compact_bloom";
 const COMPACT_ACTION_FILE_EXT: &str = "compact_action";
 
 /// An EntryOffset item size ater serialization with bincode.
-const INDEX_ENTRY_SIZE: usize = 12;
+const INDEX_ENTRY_SIZE: usize = 16;
 
 #[derive(Kinded)]
 #[kinded(derive(Hash))]
@@ -45,7 +45,8 @@ pub enum FileType {
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct EntryOffset {
     offset: u64,
-    size: u32,
+    key_size: u32,
+    full_size: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -66,6 +67,7 @@ impl EntryValue {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Entry {
+    // Key must be the first field (binary search assumes this).
     pub key: Vec<u8>,
     pub value: EntryValue,
 }

--- a/src/storage_engine/mod.rs
+++ b/src/storage_engine/mod.rs
@@ -30,7 +30,7 @@ const COMPACT_BLOOM_FILE_EXT: &str = "compact_bloom";
 const COMPACT_ACTION_FILE_EXT: &str = "compact_action";
 
 /// An EntryOffset item size ater serialization with bincode.
-const INDEX_ENTRY_SIZE: usize = 16;
+const INDEX_ENTRY_SIZE: usize = 12;
 
 #[derive(Kinded)]
 #[kinded(derive(Hash))]
@@ -44,7 +44,7 @@ pub enum FileType {
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct EntryOffset {
     offset: u64,
-    size: usize,
+    size: u32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/storage_engine/mod.rs
+++ b/src/storage_engine/mod.rs
@@ -1,5 +1,6 @@
 use std::cmp::Ordering;
 
+use kinded::Kinded;
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
 
@@ -30,6 +31,15 @@ const COMPACT_ACTION_FILE_EXT: &str = "compact_action";
 
 /// An EntryOffset item size ater serialization with bincode.
 const INDEX_ENTRY_SIZE: usize = 16;
+
+#[derive(Kinded)]
+#[kinded(derive(Hash))]
+pub enum FileType {
+    Memtable,
+    Data,
+    Index,
+    Bloom,
+}
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 struct EntryOffset {

--- a/src/tasks/compaction.rs
+++ b/src/tasks/compaction.rs
@@ -1,6 +1,5 @@
-use std::{collections::HashMap, pin::Pin, rc::Rc};
+use std::{collections::HashMap, rc::Rc};
 
-use event_listener::EventListener;
 use futures::future::{join_all, select, select_all, Either};
 use glommio::{executor, spawn_local_into, Latency, Shares, Task};
 use itertools::Itertools;
@@ -8,13 +7,14 @@ use log::error;
 
 use crate::{
     error::Result, shards::MyShard, storage_engine::lsm_tree::LSMTree,
+    utils::local_event::LocalEventListener,
 };
 
 const MIN_COMPACTION_FACTOR: usize = 2;
 
 async fn get_trees_and_listeners(
     my_shard: &MyShard,
-) -> (Vec<Rc<LSMTree>>, Vec<Pin<Box<EventListener<()>>>>) {
+) -> (Vec<Rc<LSMTree>>, Vec<LocalEventListener>) {
     while my_shard.collections.borrow().is_empty() {
         my_shard.collections_change_event.listen().await;
     }

--- a/src/utils/local_event.rs
+++ b/src/utils/local_event.rs
@@ -1,0 +1,177 @@
+use std::{
+    cell::{Cell, RefCell},
+    collections::BTreeMap,
+    future::Future,
+    pin::Pin,
+    rc::Rc,
+    task::{Context, Poll, Waker},
+};
+
+use pin_project_lite::pin_project;
+
+type SharedListeners = Rc<RefCell<BTreeMap<u64, ListenerState>>>;
+
+struct ListenerState {
+    waker: Option<Waker>,
+    done: bool,
+}
+
+pin_project! {
+    pub struct LocalEventListener {
+        #[pin]
+        id: u64,
+
+        #[pin]
+        listeners: SharedListeners,
+    }
+}
+
+impl Future for LocalEventListener {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        let mut listeners = this.listeners.borrow_mut();
+
+        if let Some(state) = listeners.get(&this.id) {
+            if state.done {
+                listeners.remove(&this.id);
+                return Poll::Ready(());
+            }
+        }
+
+        listeners.insert(
+            *this.id,
+            ListenerState {
+                waker: Some(cx.waker().clone()),
+                done: false,
+            },
+        );
+
+        Poll::Pending
+    }
+}
+
+/// An async event that is optimized for single thread use.
+pub struct LocalEvent {
+    listeners: SharedListeners,
+    last_id: Cell<u64>,
+}
+
+impl Default for LocalEvent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl LocalEvent {
+    pub fn new() -> Self {
+        Self {
+            listeners: Rc::new(RefCell::new(BTreeMap::new())),
+            last_id: Cell::new(0),
+        }
+    }
+
+    pub fn listen(&self) -> LocalEventListener {
+        let mut listeners = self.listeners.borrow_mut();
+        let id = self.last_id.get();
+
+        // Potential bug when an event has a listener with an id that already
+        // exists. Because I don't expect there to be so many listeners on a
+        // single event that exist for so long, I won't handle it.
+        self.last_id.set(id.wrapping_add(1));
+
+        listeners.insert(
+            id,
+            ListenerState {
+                waker: None,
+                done: false,
+            },
+        );
+
+        LocalEventListener {
+            id,
+            listeners: self.listeners.clone(),
+        }
+    }
+
+    pub fn notify(&self) {
+        let mut listeners = self.listeners.borrow_mut();
+        for listener in listeners.values_mut() {
+            listener.done = true;
+            if let Some(waker) = listener.waker.take() {
+                waker.wake();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use futures_lite::future::yield_now;
+    use glommio::{spawn_local, LocalExecutorBuilder, Placement};
+
+    use super::*;
+
+    fn run_with_glommio<G, F, T>(fut_gen: G)
+    where
+        G: FnOnce() -> F + Send + 'static,
+        F: Future<Output = T> + 'static,
+        T: Send + 'static,
+    {
+        let builder = LocalExecutorBuilder::new(Placement::Unbound);
+        let handle = builder.name("test").spawn(fut_gen).unwrap();
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn sticky_event() {
+        run_with_glommio(|| async {
+            let event = LocalEvent::new();
+            let listener = event.listen();
+            event.notify();
+            listener.await;
+        })
+    }
+
+    #[test]
+    fn sanity_event() {
+        run_with_glommio(|| async {
+            let set = Rc::new(Cell::new(false));
+            let event = LocalEvent::new();
+            let listener = event.listen();
+
+            let cloned_set = set.clone();
+            spawn_local(async move {
+                yield_now().await;
+                cloned_set.set(true);
+                event.notify();
+            })
+            .detach();
+
+            listener.await;
+            assert!(set.get());
+        })
+    }
+
+    #[test]
+    fn reuse_event() {
+        run_with_glommio(|| async {
+            let event = LocalEvent::new();
+
+            let listener1 = event.listen();
+            let listener2 = event.listen();
+
+            event.notify();
+            listener1.await;
+
+            let listener3 = event.listen();
+
+            event.notify();
+            listener3.await;
+            listener2.await;
+        })
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,6 +3,7 @@ use std::fs::DirEntry;
 use regex::Regex;
 
 pub mod bincode;
+pub mod local_event;
 pub mod timeout;
 pub mod timestamp_nanos;
 


### PR DESCRIPTION
- `FxHashMap` where the key is not something external that someone might DOS
- Remove of clones in page cache
- Read only key in binary search until item found, then read value
- Use a thread local event instead of a thread safe one which is less efficient (no need, we are thread per core, everything is thread local)